### PR TITLE
src/common/defs.h: add missing `<cstdint>` include (`gcc-13` fix)

### DIFF
--- a/src/common/defs.h
+++ b/src/common/defs.h
@@ -31,6 +31,7 @@
 
 //#define ENABLE_VCF_VARIANTS
 
+#include <cstdint>
 #include <string>
 using namespace std;
 


### PR DESCRIPTION
Without the change build fails on `gcc-13` as:

    mapper/../common/defs.h:53:9: error: 'uint32_t' does not name a type
       53 | typedef uint32_t ref_pos_t;
          |         ^~~~~~~~
    mapper/../common/defs.h:35:1: note: 'uint32_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
       34 | #include <string>
      +++ |+#include <cstdint>